### PR TITLE
Compatibility features

### DIFF
--- a/captools/api/client.py
+++ b/captools/api/client.py
@@ -296,7 +296,7 @@ def _encode_multipart_formdata(fields, files):
     for (key, filename, value) in files:
         L.append('--' + BOUNDARY)
         L.append(str('Content-Disposition: form-data; name="%s"; filename="%s"' % (key, filename)))
-        L.append('Content-Type: %s' % get_content_type(filename))
+        L.append(str('Content-Type: %s' % get_content_type(filename)))
         L.append('')
         L.append(value)
     L.append('--' + BOUNDARY + '--')

--- a/captools/api/client.py
+++ b/captools/api/client.py
@@ -132,6 +132,7 @@ class Client(object):
         head = {
             "Accept": "application/json",
             "User-Agent": USER_AGENT,
+            'Host': self.parsed_endpoint.netloc,
             API_TOKEN_HEADER_NAME: self.api_token,
         }
         if self.api_version in ['0.1', '0.01a']:
@@ -157,8 +158,9 @@ class Client(object):
         else:
             conn = httplib.HTTPConnection(self.parsed_endpoint.netloc)
         head = {
-            "User-Agent": USER_AGENT,
+            'User-Agent': USER_AGENT,
             API_TOKEN_HEADER_NAME: self.api_token,
+            'Host': self.parsed_endpoint.netloc
         }
         if self.api_version in ['0.1', '0.01a']:
             head[API_VERSION_HEADER_NAME] = self.api_version
@@ -192,6 +194,7 @@ class Client(object):
         h.putrequest(method, url)
         h.putheader('Content-Type', content_type)
         h.putheader('Content-Length', str(len(body)))
+        h.putheader('Host', self.parsed_endpoint.netloc)
         h.putheader('Accept', 'application/json')
         h.putheader('User-Agent', USER_AGENT)
         h.putheader(API_TOKEN_HEADER_NAME, self.api_token)
@@ -216,6 +219,7 @@ class Client(object):
         head = {
             "Content-Type": "application/json",
             "Accept": "application/json",
+            'Host': self.parsed_endpoint.netloc,
             "User-Agent": USER_AGENT,
             API_TOKEN_HEADER_NAME: self.api_token,
         }

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ License
 This is licensed under the MIT license. See LICENSE.txt.'''
 
 setup(name='captricity-python-client',
-      version='0.21',
+      version='0.22',
       description='Python client to access Captricity API',
       url='https://github.com/Captricity/captools',
       author='Captricity, Inc',


### PR DESCRIPTION
This implements two compatibility features:
- Jesse's test automation script wraps HTTP calls, which causes unicode issues when setting up the POST data. We address this by forcing the argument to str.
- Securely set shreddr clusters require the `Host` header to be set, but `captools` does not set it. This sets them. Note that in production we are not using the secure setting.