### PR TITLE
Deprecate module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
+# THIS MODULE HAS BEEN DEPRECATED
+
+The Captricity API Python Client is deprecated due to the proliferation of good
+API Client builders (e.g [`slumber`](https://github.com/samgiles/slumber)) and
+great REST client libraries (e.g [`requests`](https://github.com/requests/requests))
+that make an official client library unnecessary for most cases.
+
+Note that although this module is officially deprecated, the functionality will be supported
+for as long as Captricity supports the v1 API. However, Captricity has no intention
+of supporting `captools` beyond the v1 API.
+
+
 # Captricity API Python Client
 
 This is a Python client for the Captricity API


### PR DESCRIPTION
For @bchoi78 
cc @dave91x @ChiragG @selva-s @JoshPaulsen @kitkatbarxp @jinz @rean 

After talking with Dave and Chirag, we have agreed that the pyhon client is rarely used by our enterprise partners and customers. In addition, in most cases the `requests` and `slumber` based approach is favorable due to access to the newer endpoints we have.

As such, rather than backport many of our new API endpoints, we have decided to retire this client until we are ready for a new API SDK strategy that makes sense with the upcoming API changes.